### PR TITLE
Fix place image url issue

### DIFF
--- a/seedServer/src/main/java/deploy/DeploymentConfiguration.java
+++ b/seedServer/src/main/java/deploy/DeploymentConfiguration.java
@@ -3,6 +3,7 @@ package deploy;
 import entity.Place;
 import entity.Role;
 import entity.User;
+import facades.PlaceFacade;
 import facades.UserFacade;
 import rest.PlaceResource;
 import security.Secret;
@@ -44,7 +45,7 @@ public class DeploymentConfiguration implements ServletContextListener {
             prop.load(input);
             Secret.SHARED_SECRET = prop.getProperty("tokenSecret").getBytes();
             PlaceResource.FILE_LOCATION = prop.getProperty("fileLocation");
-            Place.BASE_IMAGE_URL = prop.getProperty("baseImageUrl");
+            PlaceFacade.BASE_IMAGE_URL = prop.getProperty("baseImageUrl");
             input.close();
 
         } catch (IOException ex) {

--- a/seedServer/src/main/java/deploy/DeploymentConfiguration.java
+++ b/seedServer/src/main/java/deploy/DeploymentConfiguration.java
@@ -44,6 +44,7 @@ public class DeploymentConfiguration implements ServletContextListener {
             prop.load(input);
             Secret.SHARED_SECRET = prop.getProperty("tokenSecret").getBytes();
             PlaceResource.FILE_LOCATION = prop.getProperty("fileLocation");
+            Place.BASE_IMAGE_URL = prop.getProperty("baseImageUrl");
             input.close();
 
         } catch (IOException ex) {

--- a/seedServer/src/main/java/entity/Place.java
+++ b/seedServer/src/main/java/entity/Place.java
@@ -11,7 +11,6 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 public class Place {
-    public static String BASE_IMAGE_URL;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -82,7 +81,7 @@ public class Place {
     }
 
     public String getImageUrl() {
-        return BASE_IMAGE_URL+imageUrl;
+        return imageUrl;
     }
 
     public void setImageUrl(String imageUrl) {

--- a/seedServer/src/main/java/entity/Place.java
+++ b/seedServer/src/main/java/entity/Place.java
@@ -11,6 +11,8 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 public class Place {
+    public static String BASE_IMAGE_URL;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
@@ -80,7 +82,7 @@ public class Place {
     }
 
     public String getImageUrl() {
-        return imageUrl;
+        return BASE_IMAGE_URL+imageUrl;
     }
 
     public void setImageUrl(String imageUrl) {

--- a/seedServer/src/main/java/facades/PlaceFacade.java
+++ b/seedServer/src/main/java/facades/PlaceFacade.java
@@ -4,7 +4,6 @@ import entity.Place;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
-import java.io.File;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public class PlaceFacade {
         }
     }
 
-    public Place addPlace(String address, String city, String zip, String desctiption, File image) {
+    public Place addPlace(String address, String city, String zip, String desctiption, String image) {
         EntityManager em = getEntityManager();
         try {
             em.getTransaction().begin();
@@ -43,7 +42,7 @@ public class PlaceFacade {
             place.setCity(city);
             place.setZip(zip);
             place.setDescription(desctiption);
-            place.setImageUrl(image.getPath());
+            place.setImageUrl(image);
             em.persist(place);
             em.getTransaction().commit();
             return place;

--- a/seedServer/src/main/java/facades/PlaceFacade.java
+++ b/seedServer/src/main/java/facades/PlaceFacade.java
@@ -11,6 +11,7 @@ import java.util.List;
  */
 public class PlaceFacade {
     EntityManagerFactory emf;
+    public static String BASE_IMAGE_URL;
 
     public PlaceFacade(EntityManagerFactory emf) {
         this.emf = emf;
@@ -42,7 +43,7 @@ public class PlaceFacade {
             place.setCity(city);
             place.setZip(zip);
             place.setDescription(desctiption);
-            place.setImageUrl(image);
+            place.setImageUrl(BASE_IMAGE_URL+image);
             em.persist(place);
             em.getTransaction().commit();
             return place;

--- a/seedServer/src/main/java/rest/PlaceResource.java
+++ b/seedServer/src/main/java/rest/PlaceResource.java
@@ -43,12 +43,12 @@ public class PlaceResource {
                                @FormDataParam("file") InputStream file,
                                @FormDataParam("file") FormDataContentDisposition fileDisposition) throws IOException {
         String fileName = fileDisposition.getFileName();
-        File image = saveFile(file, fileName);
-        Place place = facade.addPlace(address,city,zip,description,image);
+        saveFile(file, fileName);
+        Place place = facade.addPlace(address,city,zip,description,fileName);
         return Response.ok(gson.toJson(place)).build();
     }
 
-    private File saveFile(InputStream is, String fileLocation) throws IOException {
+    private void saveFile(InputStream is, String fileLocation) throws IOException {
         String location = FILE_LOCATION + fileLocation;
         File file = new File(location);
         OutputStream os = new FileOutputStream(file);
@@ -57,6 +57,5 @@ public class PlaceResource {
         while ((bytes = is.read(buffer)) != -1) {
             os.write(buffer, 0, bytes);
         }
-        return file;
     }
 }


### PR DESCRIPTION
We can specify separately both the upload path and the access URL of the image.
I use the base image URL for every new place added using the /api/places/add endpoint.
The imageUrl field in the database now contains a full valid link to the image.